### PR TITLE
fix(surface): rg -oN → -oNI to suppress filename prefix in DEC-ID collection

### DIFF
--- a/hooks/surface.sh
+++ b/hooks/surface.sh
@@ -157,7 +157,7 @@ if [[ -f "$PROJECT_ROOT/MASTER_PLAN.md" ]]; then
     CODE_DECS=""
     for dir in "${SCAN_DIRS[@]}"; do
         if command -v rg &>/dev/null; then
-            dir_decs=$(rg -oN 'DEC-[A-Z]+-[0-9]+' "$dir" \
+            dir_decs=$(rg -oNI 'DEC-[A-Z]+-[0-9]+' "$dir" \
                 --glob '*.ts' --glob '*.tsx' --glob '*.js' --glob '*.jsx' \
                 --glob '*.py' --glob '*.rs' --glob '*.go' --glob '*.java' \
                 --glob '*.c' --glob '*.cpp' --glob '*.h' --glob '*.hpp' \
@@ -182,13 +182,13 @@ if [[ -f "$PROJECT_ROOT/MASTER_PLAN.md" ]]; then
     DEPRECATED_DECS=""
     for dir in "${SCAN_DIRS[@]}"; do
         if command -v rg &>/dev/null; then
-            dir_dep=$(rg -oN '@status\s+(deprecated|superseded)' "$dir" \
+            dir_dep=$(rg -oNI '@status\s+(deprecated|superseded)' "$dir" \
                 --glob '*.ts' --glob '*.tsx' --glob '*.js' --glob '*.jsx' \
                 --glob '*.py' --glob '*.rs' --glob '*.go' --glob '*.java' \
                 --glob '*.sh' --glob '*.rb' --glob '*.php' \
                 2>/dev/null || echo "")
             # Also check inline format: Status: deprecated
-            dir_dep2=$(rg -oN 'Status:\s*(deprecated|superseded)' "$dir" \
+            dir_dep2=$(rg -oNI 'Status:\s*(deprecated|superseded)' "$dir" \
                 --glob '*.ts' --glob '*.tsx' --glob '*.js' --glob '*.jsx' \
                 --glob '*.py' --glob '*.rs' --glob '*.go' --glob '*.java' \
                 --glob '*.sh' --glob '*.rb' --glob '*.php' \
@@ -298,7 +298,7 @@ DEC_IDS_FILE=$(mktemp)
 # Collect all DEC-IDs from source
 for dir in "${SCAN_DIRS[@]}"; do
     if command -v rg &>/dev/null; then
-        rg -oN 'DEC-[A-Z]+-[0-9]+' "$dir" \
+        rg -oNI 'DEC-[A-Z]+-[0-9]+' "$dir" \
             --glob '*.{ts,tsx,js,jsx,py,rs,go,java,c,cpp,h,hpp,sh,rb,php}' \
             2>/dev/null >> "$DEC_IDS_FILE" || true
     else


### PR DESCRIPTION
## Summary
- `rg -N` suppresses line numbers but not filenames; `-I` is what suppresses filenames
- Fix four sites in `hooks/surface.sh` where the bug caused DEC-ID collection to accumulate `path:match` strings, breaking downstream `@decision` lookups
- Lines: 160 (plan-drift audit), 185/191 (deprecated-decision tracker), 301 (DECISIONS.md regeneration)
- Unblocks correct DECISIONS.md generation across all projects that use this hook

## Test plan
- [x] `bash -n hooks/surface.sh` passes
- [x] `rg -oNI 'DEC-[A-Z]+-[0-9]+' /home/j/projects/sigint --glob '*.rs'` emits plain DEC-X-N tokens with no path prefix
- [x] 4 insertions / 4 deletions, single file

🤖 Generated with [Claude Code](https://claude.com/claude-code)