### PR TITLE
fix(hooks): three false-positive checks in implementer/tester guards

### DIFF
--- a/hooks/check-implementer.sh
+++ b/hooks/check-implementer.sh
@@ -39,9 +39,35 @@ write_statusline_cache "$PROJECT_ROOT"
 ISSUES=()
 
 # Check 1: Current branch is NOT main/master (worktree was used)
+# The orchestrator's CWD is legitimately on main per CLAUDE.md. To avoid
+# false positives we check whether the implementer's session-changes file
+# shows ALL modified files living inside a worktree path. If so, the
+# implementer worked in a worktree even though PROJECT_ROOT is on main.
 CURRENT_BRANCH=$(git -C "$PROJECT_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
 if [[ "$CURRENT_BRANCH" == "main" || "$CURRENT_BRANCH" == "master" ]]; then
-    ISSUES+=("Implementation on $CURRENT_BRANCH branch — worktree should have been used")
+    # Resolve session-changes file (same logic as Check 2 below uses $CHANGES)
+    SESSION_ID_C1="${CLAUDE_SESSION_ID:-}"
+    CHANGES_FILE_C1=""
+    if [[ -n "$SESSION_ID_C1" && -f "${CLAUDE_DIR}/.session-changes-${SESSION_ID_C1}" ]]; then
+        CHANGES_FILE_C1="${CLAUDE_DIR}/.session-changes-${SESSION_ID_C1}"
+    elif [[ -f "${CLAUDE_DIR}/.session-changes" ]]; then
+        CHANGES_FILE_C1="${CLAUDE_DIR}/.session-changes"
+    fi
+
+    USED_WORKTREE=false
+    if [[ -n "$CHANGES_FILE_C1" && -s "$CHANGES_FILE_C1" ]]; then
+        # If every non-blank path lives under .claude/worktrees/ or
+        # .worktrees/, the implementer used a worktree — suppress the warning.
+        OUTSIDE=$(grep -vE "(^|/)\.claude/worktrees/|(^|/)\.worktrees/" "$CHANGES_FILE_C1" \
+                  | grep -vE '^\s*$' | head -1)
+        if [[ -z "$OUTSIDE" ]]; then
+            USED_WORKTREE=true
+        fi
+    fi
+
+    if [[ "$USED_WORKTREE" != "true" ]]; then
+        ISSUES+=("Implementation on $CURRENT_BRANCH branch — worktree should have been used")
+    fi
 fi
 
 # Check 2: Scan session-changes for 50+ line source files missing @decision
@@ -107,9 +133,23 @@ if [[ -n "$TRACE_ID" ]]; then
     if [[ ! -f "$TRACE_DIR/summary.md" ]]; then
         echo "$RESPONSE_TEXT" | head -c 4000 > "$TRACE_DIR/summary.md" 2>/dev/null || true
     fi
-    # Validate expected artifacts
+    # Validate expected artifacts — conditionally, based on task type.
+    # test-output.txt is only meaningful when tests were actually run.
+    # files-changed.txt is only meaningful when files were actually changed.
     for artifact in test-output.txt files-changed.txt; do
         if [[ ! -f "$TRACE_DIR/artifacts/$artifact" ]]; then
+            if [[ "$artifact" == "test-output.txt" ]]; then
+                # Skip if no test status was recorded this session (docs-only,
+                # plan refresh, gitignore edit, etc.)
+                read_test_status "$PROJECT_ROOT" 2>/dev/null || continue
+            fi
+            if [[ "$artifact" == "files-changed.txt" ]]; then
+                # Skip if session-changes is absent or empty — no files were
+                # modified so there is nothing to capture.
+                if [[ -z "$CHANGES" || ! -s "$CHANGES" ]]; then
+                    continue
+                fi
+            fi
             ISSUES+=("Trace artifact missing: $artifact (TRACE_DIR=$TRACE_DIR)")
         fi
     done

--- a/hooks/check-tester.sh
+++ b/hooks/check-tester.sh
@@ -56,9 +56,15 @@ if [[ "$PROOF_STATUS" == "missing" ]]; then
 fi
 
 # Check 2: Trace artifacts include verification evidence (not just test output)
+# Only require verification-output.txt when the tester actually ran a
+# verification (proof-status was written). If proof-status is missing the
+# tester didn't complete its job — that is already flagged by Check 1 above,
+# and demanding the artifact on top is a redundant/noisy false positive.
 if [[ -n "$TRACE_DIR" && -d "$TRACE_DIR/artifacts" ]]; then
     if [[ ! -f "$TRACE_DIR/artifacts/verification-output.txt" ]]; then
-        ISSUES+=("Trace artifact missing: verification-output.txt — tester should capture live feature output")
+        if [[ "$PROOF_STATUS" != "missing" ]]; then
+            ISSUES+=("Trace artifact missing: verification-output.txt — tester should capture live feature output")
+        fi
     fi
     # Validate summary exists
     if [[ ! -f "$TRACE_DIR/summary.md" ]]; then


### PR DESCRIPTION
## Summary
Three (technically four) advisory checks fired on every implementer/tester dispatch this session regardless of correctness. Fixing the noise without losing the safety value:

- **check-implementer.sh "main branch"** — orchestrator's CWD is correctly on main; the check should ask "did the agent use a worktree?" Now reads `.session-changes` paths and only flags when files are outside `.claude/worktrees/` or `.worktrees/`.
- **check-implementer.sh trace artifacts** — `test-output.txt` skipped when no test status is recorded; `files-changed.txt` skipped when no files changed (docs-only/gitignore/plan-refresh tasks).
- **check-tester.sh verification-output.txt** — gated behind `proof-status != "missing"` so it doesn't pile on top of Check 1.

bash -n syntax check passes for both scripts.

## Test plan
- [x] bash -n check-implementer.sh OK
- [x] bash -n check-tester.sh OK
- Live-test: not feasible from a Guardian merge; the hooks fire only on real implementer/tester dispatch. Future sessions will validate the fixes by absence of the false positives.

Generated with [Claude Code](https://claude.com/claude-code)