### PR TITLE
feat(hooks): demote auto-review advisories to silent-log mode

### DIFF
--- a/hooks/auto-review.sh
+++ b/hooks/auto-review.sh
@@ -49,19 +49,32 @@ EOF
     exit 0
 }
 
-# Advisory — inject the risk reason as context for the permission system.
-# Exits 0 (no opinion on permission), but provides the model with context
-# about WHY the command is risky so it can explain to the user.
+# Advisory — silent-log mode.
+# @decision DEC-AUTOREVIEW-002
+# @title Demote advisories to silent-log; stop injecting context
+# @status accepted
+# @rationale The Tier-1/2/3 classifier produces high false-positive
+#   rates on novel commands (script names, regex content, env-var names,
+#   bash keywords inside compound commands). Each false positive injects
+#   a system-reminder block into model context, polluting the working
+#   set. Silent-log preserves the audit trail and keeps the analysis
+#   running (for the permission system to pick up), but stops talking
+#   back to the model. Real risks (rm -rf, --force, --no-verify, chmod
+#   777, etc.) still trigger the normal permission prompt — the hook
+#   simply no longer narrates why.
+# Log: $HOME/.claude/auto-review-log.tsv  (timestamp, command, reason)
 advise() {
     local reason="${RISK_REASON:-unknown risk}"
-    cat <<EOF
-{
-  "hookSpecificOutput": {
-    "hookEventName": "PreToolUse",
-    "additionalContext": "auto-review risk: $reason"
-  }
-}
-EOF
+    local ts
+    ts=$(date -u +%s)
+    # TSV-sanitize: collapse tabs/newlines in the command so the log stays
+    # one-record-per-line for grep/awk consumption.
+    local cmd_safe="${COMMAND//$'\t'/ }"
+    cmd_safe="${cmd_safe//$'\n'/ }"
+    printf '%s\t%s\t%s\n' "$ts" "$cmd_safe" "$reason" \
+        >> "$HOME/.claude/auto-review-log.tsv" 2>/dev/null || true
+    # No hookSpecificOutput → no context injection. Exit 0 = no veto;
+    # the normal permission system handles the prompt without our narration.
     exit 0
 }
 


### PR DESCRIPTION
## What

`hooks/auto-review.sh` — `advise()` function rewritten. Previously emitted
`hookSpecificOutput.additionalContext` so every PreToolUse advisory
surfaced as a `<system-reminder>auto-review risk: ...</system-reminder>`
block in model context. Now appends one TSV record per call to
`$HOME/.claude/auto-review-log.tsv` (timestamp, command, reason) and
emits no `hookSpecificOutput`.

```
ts<TAB>command<TAB>reason
1714081234<TAB>git commit -m '...heredoc...'<TAB>Heredoc (<<) detected — content cannot be statically analyzed
```

## Why

The Tier-1/2/3 classifier has a high false-positive rate on novel
commands — script names that happen to contain risk keywords, regex
content inside `grep -E '...'`, env-var names, bash keywords inside
compound shells, heredocs inside ordinary `git commit -m` calls. Every
false positive pushed an advisory into model context, polluting the
working set with steady noise that added no signal. User directed this
demotion: keep the audit trail, stop talking back to the model.

## What still works

- Classifier still runs on every Bash invocation
- Tier-3 / risky commands still defer to the normal permission system
  (the hook just no longer narrates why)
- Tier-1 safe-command auto-approval unchanged — that path doesn't go
  through `advise()`
- Audit trail preserved on disk, greppable, one record per line

## Decision

`DEC-AUTOREVIEW-002` — annotation in-function (lines ~52–66) with full
rationale: classifier false-positive density, context-pollution cost,
silent-log preserves audit, real risk gating unchanged.

## Verification (pre-PR)

- [x] `bash -n hooks/auto-review.sh` — syntax clean
- [x] Live Tier-1 test (`ls /tmp`): auto-approve JSON output unchanged
- [x] Live Tier-3 test (`rm -rf`): exits 0 silently, TSV record written
- [x] Live Tier-2 test (heredoc): exits 0 silently, TSV record written

The advisory you may see firing on this PR's own commit/push commands
is exactly the false-positive class this change addresses — the
heredoc inside `git commit -m` and the `git push` advisory are noise
the silent-log mode eliminates.

## Reversibility

Single 5-line function change. `git revert 35d7f7e` is one-click.

## Out of scope

- `settings.json` (separate pre-existing modification on main)
- `.gitignore` for `auto-review-log.tsv` (security guard previously
  denied this; user can add manually if desired)
- Any other untracked files in `~/.claude`