### PR TITLE
feat(hooks): AUTOVERIFY hardware-only-waived sentinel

### DIFF
--- a/agents/tester.md
+++ b/agents/tester.md
@@ -122,6 +122,27 @@ Criteria (ALL must be true):
 
 If ANY criterion is not met, do NOT include this line. The manual approval flow will apply.
 
+### Auto-Verify Signal — Hardware-Only Gap Waiver
+
+If your verification meets ALL of these criteria, you may instead use this longer line:
+
+    AUTOVERIFY: CLEAN (hardware-only gap waived)
+
+Use this when:
+- Confidence Level is **High**
+- Every "Not tested" row in your Coverage table is a HARDWARE-AVAILABILITY gap
+  (e.g. a radio that's not plugged in, a sensor that needs a physical environment)
+- You explicitly classify those gaps as POST-MERGE validation, NOT a gate condition
+- "What Could Not Be Tested" lists ONLY hardware-only items, with explanations
+- Code paths up to the hardware boundary are Fully verified
+- "Recommended Follow-Up" is None or describes only post-merge bench testing
+
+Do NOT use this form to wave away test failures, untested code paths, or
+unverified software behavior. If a software path is untested, the strict
+AUTOVERIFY: CLEAN criteria apply.
+
+If neither sentinel fits, omit both — manual approval will apply.
+
 ## Phase 4: Request Verification
 
 1. Write `.proof-status = pending`:
@@ -129,7 +150,7 @@ If ANY criterion is not met, do NOT include this line. The manual approval flow 
    echo "pending|$(date +%s)" > <project_root>/.claude/.proof-status
    ```
 
-2. If you included `AUTOVERIFY: CLEAN`, the system handles approval automatically.
+2. If you included either AUTOVERIFY: CLEAN sentinel, the system handles approval automatically.
    Otherwise, ask the user:
    > Based on the assessment above, you can:
    > - **Approve** if the evidence is sufficient (approved, lgtm, looks good, verified, ship it)

--- a/hooks/check-tester.sh
+++ b/hooks/check-tester.sh
@@ -6,6 +6,9 @@ set -euo pipefail
 #   - .proof-status exists (at least pending)
 #   - If tester signals AUTOVERIFY: CLEAN with High confidence and full coverage,
 #     auto-writes verified status (bypasses manual approval)
+#   - If tester signals AUTOVERIFY: CLEAN (hardware-only gap waived) with High
+#     confidence, auto-writes verified even when "Not tested" rows are present
+#     for hardware-availability gaps (bypasses strict coverage check)
 #   - If still pending → exit 0 with advisory (user approval flow)
 #   - If verified → exit 0 (Guardian dispatch unblocked)
 #
@@ -18,6 +21,11 @@ set -euo pipefail
 #   verified — bypassing manual approval. Otherwise, the user must approve.
 #   Guard.sh Check 9 only blocks Bash tool writes, not hook file operations.
 #   track.sh resets proof if source files change post-verification.
+#
+# @decision DEC-TESTER-002
+# @title Hardware-only gap waiver for AUTOVERIFY auto-flip
+# @status accepted
+# @rationale See inline annotation at the hw-waived branch below.
 
 source "$(dirname "$0")/log.sh"
 source "$(dirname "$0")/context-lib.sh"
@@ -120,8 +128,40 @@ EOF
 elif [[ "$PROOF_STATUS" == "pending" ]]; then
     # --- Auto-verify: check if tester signals clean verification ---
     AUTO_VERIFIED=false
-    if echo "$RESPONSE_TEXT" | grep -q 'AUTOVERIFY: CLEAN'; then
-        # Secondary validation — reject false claims
+
+    # @decision DEC-TESTER-002
+    # @title Hardware-only gap waiver for AUTOVERIFY auto-flip
+    # @status accepted
+    # @rationale The strict AUTOVERIFY: CLEAN check rejects "Not tested" anywhere
+    #   in the response, including coverage table rows that the tester explicitly
+    #   classifies as hardware-availability gaps (not code-correctness). This new
+    #   "(hardware-only gap waived)" suffix lets the tester opt into a relaxed
+    #   check when every "Not tested" row is a hardware path that would only be
+    #   exercised post-merge in the field. Strict path is preserved unchanged for
+    #   software-only verification flows.
+    #
+    # IMPORTANT: Check the longer sentinel FIRST. The shorter "AUTOVERIFY: CLEAN"
+    # is a substring of the longer form; matching strict first would incorrectly
+    # apply strict validation to hw-waived responses.
+    if echo "$RESPONSE_TEXT" | grep -qF 'AUTOVERIFY: CLEAN (hardware-only gap waived)'; then
+        # Hardware-only gap waiver path — relaxed secondary validation
+        AV_FAIL=false
+        # Must have High confidence (markdown bold)
+        echo "$RESPONSE_TEXT" | grep -qi '\*\*High\*\*' || AV_FAIL=true
+        # Must NOT have Medium or Low confidence
+        echo "$RESPONSE_TEXT" | grep -qi '\*\*Medium\*\*\|\*\*Low\*\*' && AV_FAIL=true
+        # NOTE: "Not tested" rows ARE allowed — that is the purpose of this waiver.
+        # The tester's report must classify them as hardware-availability gaps.
+
+        if [[ "$AV_FAIL" == "false" ]]; then
+            echo "verified|$(date +%s)" > "$PROOF_FILE"
+            AUTO_VERIFIED=true
+            append_audit "$PROJECT_ROOT" "auto_verify_hw_waived" "Tester signaled AUTOVERIFY: CLEAN (hardware-only gap waived) — secondary validation passed (Not tested rows allowed)"
+        else
+            append_audit "$PROJECT_ROOT" "auto_verify_rejected" "Tester signaled AUTOVERIFY: CLEAN (hardware-only gap waived) but secondary validation failed (missing High confidence or has Medium/Low)"
+        fi
+    elif echo "$RESPONSE_TEXT" | grep -qF 'AUTOVERIFY: CLEAN'; then
+        # Strict path (unchanged) — no "Not tested" or "Partially verified" allowed
         AV_FAIL=false
         # Must have High confidence (markdown bold)
         echo "$RESPONSE_TEXT" | grep -qi '\*\*High\*\*' || AV_FAIL=true

--- a/hooks/test-check-tester.sh
+++ b/hooks/test-check-tester.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# test-check-tester.sh — Unit tests for check-tester.sh auto-verify logic.
+#
+# Tests three auto-verify scenarios by driving check-tester.sh with fake JSON
+# input and a controlled tmp .proof-status. Side-effect functions (audit log,
+# git state, trace, statusline) are stubbed via bash function overrides injected
+# before the hook sources context-lib.sh/log.sh.
+#
+# Cases:
+#   1. Strict AUTOVERIFY: CLEAN + High + no "Not tested"  → flips to verified
+#   2. Strict AUTOVERIFY: CLEAN + High + has "Not tested"  → stays pending
+#   3. AUTOVERIFY: CLEAN (hardware-only gap waived) + High + has "Not tested"
+#      → flips to verified (relaxed check)
+#
+# Usage: bash hooks/test-check-tester.sh
+# Exit:  0 if all cases pass, 1 on any failure.
+#
+# @decision DEC-TESTER-002-TEST
+# @title Tests for hardware-only gap waiver sentinel (DEC-TESTER-002)
+# @status accepted
+# @rationale Validates that the hw-waived branch in check-tester.sh correctly
+#   flips proof-status to verified when "Not tested" rows are hardware-only gaps,
+#   and that the strict path is unaffected. Stubs sourced libs to run without
+#   a real git repo or project structure.
+
+set -euo pipefail
+
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="$HOOK_DIR/check-tester.sh"
+
+PASS=0
+FAIL=0
+
+# --------------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------------
+
+make_tmp() {
+    local dir
+    dir=$(mktemp -d)
+    # Minimal .claude/ inside tmp dir
+    mkdir -p "$dir/.claude"
+    echo "pending|$(date +%s)" > "$dir/.claude/.proof-status"
+    echo "$dir"
+}
+
+# Build the JSON payload the hook reads from stdin.
+# arg1: the tester response body text
+make_json() {
+    local body="$1"
+    # Use jq to safely encode the body as a JSON string value
+    printf '{"response":%s}' "$(printf '%s' "$body" | jq -Rs .)"
+}
+
+# Run the hook with a given tmp dir and JSON payload.
+# Returns 0/1; does NOT exit on failure (we capture the result).
+run_hook() {
+    local tmp_dir="$1"
+    local json="$2"
+
+    # Environment overrides so the hook operates on tmp_dir instead of the
+    # real project root, and all side-effect calls are silently no-oped.
+    env \
+        PROJECT_ROOT="$tmp_dir" \
+        CLAUDE_DIR="$tmp_dir/.claude" \
+        TRACE_STORE="/dev/null" \
+        CLAUDE_SESSION_ID="test-$$" \
+        bash -c "
+            # Stub sourced libs BEFORE the hook runs them.
+            # We export stub functions so the hook's subshell sees them.
+
+            # log.sh stubs
+            read_input()         { cat; }
+            get_field()          { echo ''; }
+            detect_project_root(){ echo \"$tmp_dir\"; }
+            get_claude_dir()     { echo \"$tmp_dir/.claude\"; }
+            project_hash()       { echo 'testhash'; }
+            resolve_proof_file() { echo \"$tmp_dir/.claude/.proof-status\"; }
+            log_json()           { :; }
+            log_info()           { :; }
+            export -f read_input get_field detect_project_root get_claude_dir \
+                      project_hash resolve_proof_file log_json log_info
+
+            # context-lib.sh stubs
+            get_git_state()         { GIT_BRANCH='main'; GIT_DIRTY_COUNT=0; GIT_WORKTREES=''; GIT_WT_COUNT=0; }
+            get_plan_status()       { PLAN_EXISTS=false; PLAN_PHASE=''; PLAN_LIFECYCLE=none; }
+            write_statusline_cache(){ :; }
+            track_subagent_stop()   { :; }
+            detect_active_trace()   { return 1; }
+            append_audit()          { :; }
+            finalize_trace()        { :; }
+            export -f get_git_state get_plan_status write_statusline_cache \
+                      track_subagent_stop detect_active_trace append_audit finalize_trace
+
+            # Prevent the hook from re-sourcing the real libs (they would
+            # override our stubs). We do this by pre-defining the guard
+            # variables used by source guards — but these libs don't have
+            # guards, so instead we replace source with a no-op for those
+            # two specific files.
+            source() {
+                local f=\"\$1\"
+                case \"\$f\" in
+                    */log.sh|*/context-lib.sh) : ;;  # already stubbed above
+                    *) builtin source \"\$@\" ;;
+                esac
+            }
+            export -f source
+
+            # Now run the hook with the JSON on stdin
+            echo '$json' | bash '$HOOK'
+        " 2>/dev/null
+}
+
+check_case() {
+    local case_num="$1"
+    local description="$2"
+    local expected_status="$3"   # "verified" or "pending"
+    local tmp_dir="$4"
+    local json="$5"
+
+    # The hook may exit non-zero (exit 2) when proof is missing — use || true
+    run_hook "$tmp_dir" "$json" >/dev/null 2>&1 || true
+
+    local actual_status
+    actual_status=$(cut -d'|' -f1 "$tmp_dir/.claude/.proof-status" 2>/dev/null || echo "missing")
+
+    if [[ "$actual_status" == "$expected_status" ]]; then
+        echo "PASS  Case $case_num: $description"
+        (( PASS++ )) || true
+    else
+        echo "FAIL  Case $case_num: $description"
+        echo "      Expected proof-status='$expected_status', got='$actual_status'"
+        (( FAIL++ )) || true
+    fi
+
+    rm -rf "$tmp_dir"
+}
+
+# --------------------------------------------------------------------------
+# Case 1: Strict AUTOVERIFY: CLEAN + **High** + no "Not tested" → verified
+# --------------------------------------------------------------------------
+TMP=$(make_tmp)
+BODY="### Verification Assessment
+
+### Coverage
+| Area | Status | Notes |
+|------|--------|-------|
+| CLI parsing | Fully verified | All flags tested |
+| File output  | Fully verified | Output matches |
+
+### What Could Not Be Tested
+None
+
+### Confidence Level
+**High** — All core paths exercised, output matches expectations.
+
+### Recommended Follow-Up
+None
+
+AUTOVERIFY: CLEAN"
+
+JSON=$(make_json "$BODY")
+check_case 1 "Strict AUTOVERIFY: CLEAN + High + no Not-tested row => verified" "verified" "$TMP" "$JSON"
+
+# --------------------------------------------------------------------------
+# Case 2: Strict AUTOVERIFY: CLEAN + **High** + has "Not tested" → stays pending
+# --------------------------------------------------------------------------
+TMP=$(make_tmp)
+BODY="### Verification Assessment
+
+### Coverage
+| Area | Status | Notes |
+|------|--------|-------|
+| CLI parsing     | Fully verified | All flags tested |
+| Live BT hardware | Not tested     | No Ubertooth connected |
+
+### Confidence Level
+**High** — Software paths exercised; hardware path not available.
+
+AUTOVERIFY: CLEAN"
+
+JSON=$(make_json "$BODY")
+check_case 2 "Strict AUTOVERIFY: CLEAN + High + Not-tested row => stays pending" "pending" "$TMP" "$JSON"
+
+# --------------------------------------------------------------------------
+# Case 3: AUTOVERIFY: CLEAN (hardware-only gap waived) + High + "Not tested" → verified
+# --------------------------------------------------------------------------
+TMP=$(make_tmp)
+BODY="### Verification Assessment
+
+### Coverage
+| Area | Status | Notes |
+|------|--------|-------|
+| Subprocess cleanup | Fully verified | Process exits cleanly |
+| Live BT hardware   | Not tested     | No Ubertooth connected — hardware-availability gap, post-merge bench test only |
+
+### What Could Not Be Tested
+Live Ubertooth hardware path — device not connected. Code up to the hardware boundary is fully exercised.
+
+### Confidence Level
+**High** — All software paths verified. Hardware gap explicitly classified as non-blocking.
+
+### Recommended Follow-Up
+Post-merge bench test with Ubertooth once hardware is available.
+
+AUTOVERIFY: CLEAN (hardware-only gap waived)"
+
+JSON=$(make_json "$BODY")
+check_case 3 "AUTOVERIFY: CLEAN (hardware-only gap waived) + High + Not-tested row => verified" "verified" "$TMP" "$JSON"
+
+# --------------------------------------------------------------------------
+# Summary
+# --------------------------------------------------------------------------
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+
+if [[ "$FAIL" -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## The Bug

`hooks/check-tester.sh`'s strict `AUTOVERIFY: CLEAN` check rejects ANY occurrence of "Not tested" in the tester response — including coverage table rows that the tester explicitly classifies as hardware-availability gaps (radio not connected, sensor needs physical environment, etc.). This forces manual approval even when verification is otherwise clean and the tester reports HIGH confidence.

Bit us today on akaei PRs #53 (Ubertooth low-energy capture) and #54 (LANA antenna-aware sensitivity profile) — both had hardware-only "Not tested" rows for paths that can only be exercised post-merge in the field.

## The Fix

New opt-in sentinel: `AUTOVERIFY: CLEAN (hardware-only gap waived)`

- Tester opts in **only when** every "Not tested" row is a hardware-availability gap, code paths up to the hardware boundary are fully verified, and "What Could Not Be Tested" lists only post-merge bench testing
- Hook still requires `**High**` confidence; still rejects `**Medium**` or `**Low**`
- Strict `AUTOVERIFY: CLEAN` path is preserved byte-for-byte for software-only flows
- Longer sentinel checked **first** (it's a superstring — strict-first would misroute hw-waived responses)
- Audit log distinguishes `auto_verify_hw_waived` from `auto_verify`
- `agents/tester.md` adds an "Auto-Verify Signal — Hardware-Only Gap Waiver" subsection with explicit prohibition: do NOT use this to wave away software test failures or untested code paths

## Test Coverage

New `hooks/test-check-tester.sh` (220 lines, executable):
- Case 1: Strict + High + no Not-tested row -> verified
- Case 2: Strict + High + Not-tested row -> stays pending (unchanged behavior)
- Case 3: hw-waived + High + Not-tested row -> verified (the fix)

Tester replicated all three and added two adversarial cases:
- hw-waived + **Medium** confidence -> stays pending (correctly rejected)
- Strict + High + Not-tested -> stays pending (regression check)

5/5 pass. Tester confidence: HIGH. AUTOVERIFY: CLEAN, no caveats.

## Test plan

- [ ] Local: `bash hooks/test-check-tester.sh` passes 3/3
- [ ] Next akaei PR with hardware-only gaps should auto-verify on its own (no manual approval needed) when the tester uses the new sentinel
- [ ] Audit log entries appear as `auto_verify_hw_waived` rather than `auto_verify` for the relaxed path

## References

- akaei PR #53 — Ubertooth low-energy capture (manual approval forced by strict gate)
- akaei PR #54 — LANA antenna-aware sensitivity profile (same)
- `@decision DEC-TESTER-002`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>